### PR TITLE
schema.org markup for index

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
       <title>UWLSWD</title>
       <link href="https://uwlib-cams.github.io/webviews/css/index_pages.css" rel="stylesheet" type="text/css">
-      <link rel="icon" type="image/png" href="https://uwlib-cams.github.io/webviews/images/book.png"><script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"DataCatalog","@id":"https:\/\/uwlib-cams.github.io\/uwlswd\/","name":"University of Washington Libraries Semantic Web Data","description":"Catalog of datasets and vocabularies published and maintained by the University of Washington Libraries Cataloging and Metadata Services Department.","creator":{"@type":"LibrarySystem","@id":"http:\/\/viaf.org\/viaf\/139541794","name":"University of Washington Libraries"},"publisher":{"@type":"LibrarySystem","@id":"http:\/\/viaf.org\/viaf\/139541794","name":"University of Washington Libraries"},"datePublished":"2023","inLanguage":"en","encodingFormat":"html","license":"http:\/\/creativecommons.org\/publicdomain\/zero\/1.0"}</script></head>
+      <link rel="icon" type="image/png" href="https://uwlib-cams.github.io/webviews/images/book.png"><script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"DataCatalog","@id":"https:\/\/uwlib-cams.github.io\/uwlswd\/","name":"University of Washington Libraries Semantic Web Data","description":"Catalog of datasets and vocabularies published and maintained by the University of Washington Libraries Cataloging and Metadata Services Department.","creator":{"@type":"LibrarySystem","@id":"http:\/\/viaf.org\/viaf\/139541794","name":"University of Washington Libraries"},"publisher":{"@type":"LibrarySystem","@id":"http:\/\/viaf.org\/viaf\/139541794","name":"University of Washington Libraries"},"datePublished":"2023","inLanguage":"en","encodingFormat":"text\/html","license":"http:\/\/creativecommons.org\/publicdomain\/zero\/1.0"}</script></head>
    <body>
       <h1 id="top">University of Washington Libraries Semantic Web Data</h1>
       <p>The following datasets and vocabularies are published and maintained by the <a href="https://www.lib.washington.edu/cams">University of Washington Libraries Cataloging and Metadata Services department</a>. For additional information about linked-data initiatives at the University of Washington
@@ -205,9 +205,13 @@
          <p><a href="#top">Return to categories</a></p>
       </div>
       <h3 id="RDFOntologyExtension">RDF Ontology Extension</h3>
-      <h4>RDA Application Profile Extension</h4>
+      <h4>University of Washington Libraries RDA Application Profile Extension</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/">https://doi.org/</a></p>
+         <p><a href="https://doi.org/10.6069/UWLIB.55.D.4">https://doi.org/10.6069/UWLIB.55.D.4</a></p>
+         <p class="italic">Properties required to extend local RDA (Resource Description and Access) application
+            profile. Extension required because RDA did not provide some elements/properties needed
+            to fully describe our resources. Profile was written as part of the LD4P2 grant project
+            in the interest of producing data entry forms in the Sinopia Linked Data Editor.</p>
       </div>
       <div class="italic return_to_top">
          <p><a href="#top">Return to categories</a></p>
@@ -225,18 +229,22 @@
          <p><a href="https://doi.org/10.6069/UWLIB.55.B.2">https://doi.org/10.6069/UWLIB.55.B.2</a></p>
          <p class="italic">Vocabulary for describing processes run on linked data datasets.</p>
       </div>
-      <h4>Classes: University of Washington Libraries rdfs:Class definitions</h4>
+      <h4>University of Washington Libraries rdfs:Class Definitions</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/">https://doi.org/</a></p>
+         <p><a href="https://doi.org/10.6069/UWLIB.55.D.1">https://doi.org/10.6069/UWLIB.55.D.1</a></p>
+         <p class="italic">RDF dataset describing locally-defined classes used in University of Washington Libraries
+            Semantic Web Data.</p>
       </div>
       <h4>Linked Data Platforms</h4>
       <div class="margin_left_30">
          <p><a href="https://doi.org/10.6069/UWLIB.55.D.2">https://doi.org/10.6069/UWLIB.55.D.2</a></p>
          <p class="italic">Platforms (or applications) used to process RDF datasets.</p>
       </div>
-      <h4>University of Washington Libraries rdf:Property definitions</h4>
+      <h4>University of Washington Libraries rdf:Property Definitions</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/">https://doi.org/</a></p>
+         <p><a href="https://doi.org/10.6069/UWLIB.55.D.3">https://doi.org/10.6069/UWLIB.55.D.3</a></p>
+         <p class="italic">RDF dataset describing locally-minted properties used in University of Washington
+            Libraries RDF data.</p>
       </div>
       <div class="italic return_to_top">
          <p><a href="#top">Return to categories</a></p>

--- a/index.html
+++ b/index.html
@@ -1,25 +1,26 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="en">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
       <title>UWLSWD</title>
       <link href="https://uwlib-cams.github.io/webviews/css/index_pages.css" rel="stylesheet" type="text/css">
-      <link rel="icon" type="image/png" href="https://uwlib-cams.github.io/webviews/images/book.png">
-   </head>
+      <link rel="icon" type="image/png" href="https://uwlib-cams.github.io/webviews/images/book.png"><script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"DataCatalog","@id":"https:\/\/uwlib-cams.github.io\/uwlswd\/","name":"University of Washington Libraries Semantic Web Data","description":"Catalog of datasets and vocabularies published and maintained by the University of Washington Libraries Cataloging and Metadata Services Department.","creator":{"@type":"LibrarySystem","@id":"http:\/\/viaf.org\/viaf\/139541794","name":"University of Washington Libraries"},"publisher":{"@type":"LibrarySystem","@id":"http:\/\/viaf.org\/viaf\/139541794","name":"University of Washington Libraries"},"datePublished":"2023","inLanguage":"en","encodingFormat":"html","license":"http:\/\/creativecommons.org\/publicdomain\/zero\/1.0"}</script></head>
    <body>
       <h1 id="top">University of Washington Libraries Semantic Web Data</h1>
       <p>The following datasets and vocabularies are published and maintained by the <a href="https://www.lib.washington.edu/cams">University of Washington Libraries Cataloging and Metadata Services department</a>. For additional information about linked-data initiatives at the University of Washington
          Libraries, visit the <a href="https://www.lib.washington.edu/cams/swr">University of Washington Libraries Semantic Web Resources</a> page.</p>
-      <h2>Categories</h2>
-      <ul>
-         <li><a href="#SKOS Concept Schemes">SKOS Concept Schemes</a></li>
-         <li><a href="#SKOS Concept Schemes for MARC 00X Values">SKOS Concept Schemes for MARC 00X Values</a></li>
-         <li><a href="#RDF Ontology Extension">RDF Ontology Extension</a></li>
-         <li><a href="#RDF Vocabularies">RDF Vocabularies</a></li>
-         <li><a href="#RDF Dataset Description">RDF Dataset Description</a></li>
-         <li><a href="#Linked Open Cultural Heritage Datasets">Linked Open Cultural Heritage Datasets</a></li>
-      </ul>
-      <h3 id="SKOS Concept Schemes">SKOS Concept Schemes</h3>
+      <nav>
+         <h2>Categories</h2>
+         <ul>
+            <li><a href="#SKOSConceptSchemes">SKOS Concept Schemes</a></li>
+            <li><a href="#SKOSConceptSchemesforMARC00XValues">SKOS Concept Schemes for MARC 00X Values</a></li>
+            <li><a href="#RDFOntologyExtension">RDF Ontology Extension</a></li>
+            <li><a href="#RDFVocabularies">RDF Vocabularies</a></li>
+            <li><a href="#RDFDatasetDescription">RDF Dataset Description</a></li>
+            <li><a href="#LinkedOpenCulturalHeritageDatasets">Linked Open Cultural Heritage Datasets</a></li>
+         </ul>
+      </nav>
+      <h3 id="SKOSConceptSchemes">SKOS Concept Schemes</h3>
       <h4>Linked Data Vocabularies: Children's Literature Categories</h4>
       <div class="margin_left_30">
          <p><a href="https://doi.org/10.6069/UWLIB.55.B.3">https://doi.org/10.6069/UWLIB.55.B.3</a></p>
@@ -38,26 +39,26 @@
       <div class="italic return_to_top">
          <p><a href="#top">Return to categories</a></p>
       </div>
-      <h3 id="SKOS Concept Schemes for MARC 00X Values">SKOS Concept Schemes for MARC 00X Values</h3>
+      <h3 id="SKOSConceptSchemesforMARC00XValues">SKOS Concept Schemes for MARC 00X Values</h3>
       <h4>Music: format of music</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.06xx-6744">https://doi.org/10.6069/uwlswd.06xx-6744</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.06XX-6744">https://doi.org/10.6069/UWLSWD.06XX-6744</a></p>
          <p class="italic">Indicates the format of a musical composition (e.g., piano-conductor score).</p>
       </div>
       <h4>Continuing: original alphabet or script of title</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.084w-3778">https://doi.org/10.6069/uwlswd.084w-3778</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.084W-3778">https://doi.org/10.6069/UWLSWD.084W-3778</a></p>
          <p class="italic">Indicates the original alphabet or script of the language of the title on the source
             item upon which the key title is based.</p>
       </div>
       <h4>Maps: relief</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.1c2x-cj09">https://doi.org/10.6069/uwlswd.1c2x-cj09</a></p>
-         <p class="italic">Indicates the projection used in producing the item.</p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.1C2X-CJ09">https://doi.org/10.6069/UWLSWD.1C2X-CJ09</a></p>
+         <p class="italic">Indicate the relief type specified on the item.</p>
       </div>
       <h4>Music: literary text of sound recordings</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.23tq-5e25">https://doi.org/10.6069/uwlswd.23tq-5e25</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.23TQ-5E25">https://doi.org/10.6069/UWLSWD.23TQ-5E25</a></p>
          <p class="italic">Indicates the type of literary text contained in a nonmusical sound recording.</p>
       </div>
       <h4>Form of material</h4>
@@ -67,155 +68,151 @@
       </div>
       <h4>Some: government publication</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.2eg3-1x53">https://doi.org/10.6069/uwlswd.2eg3-1x53</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.2EG3-1X53">https://doi.org/10.6069/UWLSWD.2EG3-1X53</a></p>
          <p class="italic">Indicates whether the item is published or produced by or for an international, provincial,
             national, state, or local government agency, or by any subdivision of such a body,
             and, if so, the jurisdictional level of the agency.</p>
       </div>
       <h4>Computer: form of item</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.3d5s-zx23">https://doi.org/10.6069/uwlswd.3d5s-zx23</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.3D5S-ZX23">https://doi.org/10.6069/UWLSWD.3D5S-ZX23</a></p>
          <p class="italic">Specifies the form of material for the computer file.</p>
       </div>
       <h4>Continuing: form of original item</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.42d2-ca58">https://doi.org/10.6069/uwlswd.42d2-ca58</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.42D2-CA58">https://doi.org/10.6069/UWLSWD.42D2-CA58</a></p>
          <p class="italic">Indicates the form of material in which an item was originally published.</p>
       </div>
       <h4>All: type of date or publication status</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.4a8z-tq62">https://doi.org/10.6069/uwlswd.4a8z-tq62</a></p>
-         <p class="italic">Indicates type of date given. Or, for continuing resources, indicates
-            publication status.</p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.4A8Z-TQ62">https://doi.org/10.6069/UWLSWD.4A8Z-TQ62</a></p>
+         <p class="italic">Indicates type of date given. Or, for continuing resources, indicates publication
+            status.</p>
       </div>
       <h4>Maps: projection</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.4jrs-m847">https://doi.org/10.6069/uwlswd.4jrs-m847</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.4JRS-M847">https://doi.org/10.6069/UWLSWD.4JRS-M847</a></p>
          <p class="italic">Indicates the projection used in producing the item.</p>
       </div>
       <h4>Continuing: type of continuing resource</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.62zz-1534">https://doi.org/10.6069/uwlswd.62zz-1534</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.62ZZ-1534">https://doi.org/10.6069/UWLSWD.62ZZ-1534</a></p>
          <p class="italic">Indicates the type of continuing resource.</p>
       </div>
       <h4>Some: nature of contents</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.633m-h220">https://doi.org/10.6069/uwlswd.633m-h220</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.633M-H220">https://doi.org/10.6069/UWLSWD.633M-H220</a></p>
          <p class="italic">Indicates whether a significant part of the item is or contains certain types of material.</p>
       </div>
       <h4>Music: form of composition</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.8rpj-ek77">https://doi.org/10.6069/uwlswd.8rpj-ek77</a></p>
-         <p class="italic">Indicates the form of composition.</p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.8RPJ-EK77">https://doi.org/10.6069/UWLSWD.8RPJ-EK77</a></p>
+         <p class="italic">Indicates the form of composition. Is based on the terminology in the work itself.
+            Also includes musical genres (e.g., Ragtime music).</p>
       </div>
       <h4>Some: target audience</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.aec4-nv40">https://doi.org/10.6069/uwlswd.aec4-nv40</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.AEC4-NV40">https://doi.org/10.6069/UWLSWD.AEC4-NV40</a></p>
          <p class="italic">Indicates the audience for which the item is intended.</p>
       </div>
       <h4>Music: transposition and arrangement</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.axz0-z371">https://doi.org/10.6069/uwlswd.axz0-z371</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.AXZ0-Z371">https://doi.org/10.6069/UWLSWD.AXZ0-Z371</a></p>
          <p class="italic">Whether all or part of the item being cataloged is a transposition and/or arrangement
             of another work.</p>
       </div>
       <h4>Some: form of item</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.dh5m-5y16">https://doi.org/10.6069/uwlswd.dh5m-5y16</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.DH5M-5Y16">https://doi.org/10.6069/UWLSWD.DH5M-5Y16</a></p>
          <p class="italic">Specifies the form of material.</p>
       </div>
       <h4>Visual: technique</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.eje7-jq11">https://doi.org/10.6069/uwlswd.eje7-jq11</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.EJE7-JQ11">https://doi.org/10.6069/UWLSWD.EJE7-JQ11</a></p>
          <p class="italic">Indicates the technique used in creating motion in motion pictures or videorecordings.</p>
       </div>
       <h4>Books: literary form</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.f447-ax91">https://doi.org/10.6069/uwlswd.f447-ax91</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.F447-AX91">https://doi.org/10.6069/UWLSWD.F447-AX91</a></p>
          <p class="italic">Indicates the literary form of an item.</p>
       </div>
       <h4>Continuing: frequency</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.ggnh-4s58">https://doi.org/10.6069/uwlswd.ggnh-4s58</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.GGNH-4S58">https://doi.org/10.6069/UWLSWD.GGNH-4S58</a></p>
          <p class="italic">Indicates the frequency of an item. In the case of integrating resources, updates
             to an item.</p>
       </div>
       <h4>Books: illustrations</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.gq3z-mv97">https://doi.org/10.6069/uwlswd.gq3z-mv97</a></p>
-         <p class="italic">Indicates the presence of types of illustrations in the
-            item.</p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.GQ3Z-MV97">https://doi.org/10.6069/UWLSWD.GQ3Z-MV97</a></p>
+         <p class="italic">Indicates the presence of types of illustrations in the item.</p>
       </div>
       <h4>Continuing: nature of entire work</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.jfr5-z647">https://doi.org/10.6069/uwlswd.jfr5-z647</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.JFR5-Z647">https://doi.org/10.6069/UWLSWD.JFR5-Z647</a></p>
          <p class="italic">Indicates the nature of an item if it consists entirely of a certain type of material.</p>
       </div>
       <h4>Computer: type of computer file</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.mkjn-bp10">https://doi.org/10.6069/uwlswd.mkjn-bp10</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.MKJN-BP10">https://doi.org/10.6069/UWLSWD.MKJN-BP10</a></p>
          <p class="italic">Indicates the type of computer file described in the bibliographic record.</p>
       </div>
       <h4>Continuing: regularity</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.npns-e903">https://doi.org/10.6069/uwlswd.npns-e903</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.NPNS-E903">https://doi.org/10.6069/UWLSWD.NPNS-E903</a></p>
          <p class="italic">Indicates the intended regularity of an item.</p>
       </div>
       <h4>Music: accompanying matter</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.nt0v-d633">https://doi.org/10.6069/uwlswd.nt0v-d633</a></p>
-         <p class="italic">Indicates the contents of program notes and other accompanying material for
-            sound recording, music manuscripts, or notated music.</p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.NT0V-D633">https://doi.org/10.6069/UWLSWD.NT0V-D633</a></p>
+         <p class="italic">Indicates the contents of program notes and other accompanying material for sound
+            recording, music manuscripts, or notated music.</p>
       </div>
       <h4>Visual: type of visual material</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.qgc0-9r48">https://doi.org/10.6069/uwlswd.qgc0-9r48</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.QGC0-9R48">https://doi.org/10.6069/UWLSWD.QGC0-9R48</a></p>
          <p class="italic">Indicates the type of visual material being described.</p>
       </div>
       <h4>Maps: special format characteristics</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.rw25-p125">https://doi.org/10.6069/uwlswd.rw25-p125</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.RW25-P125">https://doi.org/10.6069/UWLSWD.RW25-P125</a></p>
          <p class="italic">Indicates the special format characteristics of the map.</p>
       </div>
       <h4>Maps: type of cartographic material</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.vw5v-gh79">https://doi.org/10.6069/uwlswd.vw5v-gh79</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.VW5V-GH79">https://doi.org/10.6069/UWLSWD.VW5V-GH79</a></p>
          <p class="italic">Indicates the type of cartographic item described.</p>
       </div>
       <h4>Books: biography</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.x4ce-sd21">https://doi.org/10.6069/uwlswd.x4ce-sd21</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.X4CE-SD21">https://doi.org/10.6069/UWLSWD.X4CE-SD21</a></p>
          <p class="italic">Indicates whether or not an item contains biographical material, and if so, what the
             biographical characteristics are.</p>
       </div>
       <h4>Continuing: entry convention</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.ypcx-6882">https://doi.org/10.6069/uwlswd.ypcx-6882</a></p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.YPCX-6882">https://doi.org/10.6069/UWLSWD.YPCX-6882</a></p>
          <p class="italic">Indicates whether the item was cataloged according to successive entry, latest entry,
             or integrated entry cataloging conventions.</p>
       </div>
       <h4>Music: music parts</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.ywjs-vr46">https://doi.org/10.6069/uwlswd.ywjs-vr46</a></p>
-         <p class="italic">Indicates whether the item being cataloged is, or contains parts.</p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.YWJS-VR46">https://doi.org/10.6069/UWLSWD.YWJS-VR46</a></p>
+         <p class="italic">Indicates whether the item being cataloged is, or contains parts. Is not used to indicate
+            that parts may exist elsewhere.</p>
       </div>
       <div class="italic return_to_top">
          <p><a href="#top">Return to categories</a></p>
       </div>
-      <h3 id="RDF Ontology Extension">RDF Ontology Extension</h3>
+      <h3 id="RDFOntologyExtension">RDF Ontology Extension</h3>
       <h4>RDA Application Profile Extension</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/UWLIB.55.D.4">https://doi.org/10.6069/UWLIB.55.D.4</a></p>
-         <p class="italic">Properties required to extend local RDA (Resource Description and Access) application
-            profile. Extension required because RDA did not provide some elements/properties needed
-            to fully describe our resources. Profile was written as part of the LD4P2 grant project
-            in the interest of producing data entry forms in the linked data cataloging environment
-            called Sinopia.</p>
+         <p><a href="https://doi.org/">https://doi.org/</a></p>
       </div>
       <div class="italic return_to_top">
          <p><a href="#top">Return to categories</a></p>
       </div>
-      <h3 id="RDF Vocabularies">RDF Vocabularies</h3>
+      <h3 id="RDFVocabularies">RDF Vocabularies</h3>
       <h4>Linked Data Platform Vocabulary</h4>
       <div class="margin_left_30">
          <p><a href="https://doi.org/10.6069/UWLIB.55.B.1">https://doi.org/10.6069/UWLIB.55.B.1</a></p>
@@ -226,15 +223,11 @@
       <h4>RDF Vocabulary for Linked Data Processes</h4>
       <div class="margin_left_30">
          <p><a href="https://doi.org/10.6069/UWLIB.55.B.2">https://doi.org/10.6069/UWLIB.55.B.2</a></p>
-         <p class="italic"> The RDF triples below define a vocabulary for describing processes run on linked
-            data datasets. This vocabulary was originally intended as administrative and provenance
-            data for RDF datasets produced at the University of Washington Libraries.</p>
+         <p class="italic">Vocabulary for describing processes run on linked data datasets.</p>
       </div>
       <h4>Classes: University of Washington Libraries rdfs:Class definitions</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/UWLIB.55.D.1">https://doi.org/10.6069/UWLIB.55.D.1</a></p>
-         <p class="italic">This RDF dataset is a description of classes needed to describe University of Washington
-            Libraries resources.</p>
+         <p><a href="https://doi.org/">https://doi.org/</a></p>
       </div>
       <h4>Linked Data Platforms</h4>
       <div class="margin_left_30">
@@ -243,15 +236,12 @@
       </div>
       <h4>University of Washington Libraries rdf:Property definitions</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/UWLIB.55.D.3">https://doi.org/10.6069/UWLIB.55.D.3</a></p>
-         <p class="italic">Describes a digital collection in which an entity is referenced. The digital collection
-            metadata is the source of the data describing the entity. This property is useful
-            for tracking the digital collections that contributed to the local graph.</p>
+         <p><a href="https://doi.org/">https://doi.org/</a></p>
       </div>
       <div class="italic return_to_top">
          <p><a href="#top">Return to categories</a></p>
       </div>
-      <h3 id="RDF Dataset Description">RDF Dataset Description</h3>
+      <h3 id="RDFDatasetDescription">RDF Dataset Description</h3>
       <h4>University of Washington Libraries' Semantic Web Data</h4>
       <div class="margin_left_30">
          <p><a href="https://doi.org/10.6069/UWLIB.55.A">https://doi.org/10.6069/UWLIB.55.A</a></p>
@@ -263,41 +253,41 @@
       <div class="italic return_to_top">
          <p><a href="#top">Return to categories</a></p>
       </div>
-      <h3 id="Linked Open Cultural Heritage Datasets">Linked Open Cultural Heritage Datasets</h3>
+      <h3 id="LinkedOpenCulturalHeritageDatasets">Linked Open Cultural Heritage Datasets</h3>
       <h4>Instances of the SourceResource Class</h4>
       <div class="margin_left_30">
          <p><a href="https://doi.org/10.6069/UWLIB.55.A.3.1">https://doi.org/10.6069/UWLIB.55.A.3.1</a></p>
-         <p class="italic">Instances of the class  represented in the University of Washington digital collections;
-            the class is taken from the Digital Public Library of America Metadata Application
-            Profile 5.0</p>
+         <p class="italic">Instances of the class http://dp.la/about/map/SourceResource represented in the University
+            of Washington digital collections; the class is taken from the Digital Public Library
+            of America Metadata Application Profile 5.0</p>
       </div>
       <h4>Instances of the Aggregation Class</h4>
       <div class="margin_left_30">
          <p><a href="https://doi.org/10.6069/UWLIB.55.A.3.2">https://doi.org/10.6069/UWLIB.55.A.3.2</a></p>
-         <p class="italic">Instances of the class  represented in the University of Washington digital collections;
-            the class is taken from the Digital Public Library of America Metadata Application
-            Profile 5.0</p>
+         <p class="italic">Instances of the class http://www.openarchives.org/ore/terms/Aggregation represented
+            in the University of Washington digital collections; the class is taken from the Digital
+            Public Library of America Metadata Application Profile 5.0</p>
       </div>
       <h4>Instances of the WebResource Class</h4>
       <div class="margin_left_30">
          <p><a href="https://doi.org/10.6069/UWLIB.55.A.3.3">https://doi.org/10.6069/UWLIB.55.A.3.3</a></p>
-         <p class="italic">Instances of the class  represented in the University of Washington digital collections;
-            the class is taken from the Digital Public Library Metadata of America Application
-            Profile 5.0</p>
+         <p class="italic">Instances of the class http://www.europeana.eu/schemas/edm/WebResource represented
+            in the University of Washington digital collections; the class is taken from the Digital
+            Public Library Metadata of America Application Profile 5.0</p>
       </div>
       <h4>Instances of the Collection Class</h4>
       <div class="margin_left_30">
          <p><a href="https://doi.org/10.6069/UWLIB.55.A.3.4">https://doi.org/10.6069/UWLIB.55.A.3.4</a></p>
-         <p class="italic">Instances of the class  represented in the University of Washington digital collections;
-            the class is taken from the Digital Public Library of America Metadata Application
-            Profile 5.0</p>
+         <p class="italic">Instances of the class http://purl.org/dc/dcmitype/Collection represented in the University
+            of Washington digital collections; the class is taken from the Digital Public Library
+            of America Metadata Application Profile 5.0</p>
       </div>
       <h4>Instances of the RightsStatement Class</h4>
       <div class="margin_left_30">
          <p><a href="https://doi.org/10.6069/UWLIB.55.A.3.5">https://doi.org/10.6069/UWLIB.55.A.3.5</a></p>
-         <p class="italic">Instances of the class  represented in the University of Washington digital collections;
-            the class is taken from the Digital Public Library of America Metadata Application
-            Profile 5.0</p>
+         <p class="italic">Instances of the class http://purl.org/dc/terms/RightsStatement represented in the
+            University of Washington digital collections; the class is taken from the Digital
+            Public Library of America Metadata Application Profile 5.0</p>
       </div>
       <h4>Instances of the Agent Class</h4>
       <div class="margin_left_30">
@@ -308,9 +298,9 @@
       </div>
       <h4>Instances of the ProvenanceStatement Class</h4>
       <div class="margin_left_30">
-         <p><a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a></p>
-         <p class="italic">Instances of the Dublin Core ProvenanceStatement class, originally intended for descriptions
-            of provenance statements in the University of Washington Libraries' Semantic Web Data.</p>
+         <p><a href="https://doi.org/10.6069/UWLSWD.2E2B-Y833">https://doi.org/10.6069/UWLSWD.2E2B-Y833</a></p>
+         <p class="italic">Instances of the class http://purl.org/dc/terms/ProvenanceStatement referenced in
+            UW Libraries semantic web data.</p>
       </div>
       <div class="italic return_to_top">
          <p><a href="#top">Return to categories</a></p>

--- a/xml/temp_index_categories.xml
+++ b/xml/temp_index_categories.xml
@@ -37,14 +37,14 @@
         <resource>Music: music parts</resource>
     </category>
     <category label="RDF Ontology Extension">
-        <resource>RDA Application Profile Extension</resource>
+        <resource>University of Washington Libraries RDA Application Profile Extension</resource>
     </category>
     <category label="RDF Vocabularies">
         <resource>Linked Data Platform Vocabulary</resource>
         <resource>RDF Vocabulary for Linked Data Processes</resource>
-        <resource>Classes: University of Washington Libraries rdfs:Class definitions</resource>
+        <resource>University of Washington Libraries rdfs:Class Definitions</resource>
         <resource>Linked Data Platforms</resource>
-        <resource>University of Washington Libraries rdf:Property definitions</resource>
+        <resource>University of Washington Libraries rdf:Property Definitions</resource>
     </category>
     <category label="RDF Dataset Description">
         <resource>University of Washington Libraries' Semantic Web Data</resource>

--- a/xsl/temp_index.xsl
+++ b/xsl/temp_index.xsl
@@ -44,7 +44,7 @@
             </fn:map>
             <fn:string key="datePublished">2023</fn:string>
             <fn:string key="inLanguage">en</fn:string>
-            <fn:string key="encodingFormat">html</fn:string>
+            <fn:string key="encodingFormat">text/html</fn:string>
             <fn:string key="license">http://creativecommons.org/publicdomain/zero/1.0</fn:string>
         </fn:map>
     </xsl:variable>

--- a/xsl/temp_index.xsl
+++ b/xsl/temp_index.xsl
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:datacite="http://datacite.org/schema/kernel-4"
+    xmlns:fn="http://www.w3.org/2005/xpath-functions"
     exclude-result-prefixes="#all" expand-text="yes" version="3.0">
     <xsl:output method="html" indent="yes"/>
 
@@ -24,6 +25,29 @@
             </xsl:for-each>
         </collection>
     </xsl:variable>
+    <xsl:variable name="schema">
+        <fn:map>
+            <fn:string key="@context">http://schema.org</fn:string>
+            <fn:string key="@type">DataCatalog</fn:string>
+            <fn:string key="@id">https://uwlib-cams.github.io/uwlswd/</fn:string>
+            <fn:string key="name">University of Washington Libraries Semantic Web Data</fn:string>
+            <fn:string key="description">Catalog of datasets and vocabularies published and maintained by the University of Washington Libraries Cataloging and Metadata Services Department.</fn:string>
+            <fn:map key="creator">
+                <fn:string key="@type">LibrarySystem</fn:string>
+                <fn:string key="@id">http://viaf.org/viaf/139541794</fn:string>
+                <fn:string key="name">University of Washington Libraries</fn:string>
+            </fn:map>
+            <fn:map key="publisher">
+                <fn:string key="@type">LibrarySystem</fn:string>
+                <fn:string key="@id">http://viaf.org/viaf/139541794</fn:string>
+                <fn:string key="name">University of Washington Libraries</fn:string>
+            </fn:map>
+            <fn:string key="datePublished">2023</fn:string>
+            <fn:string key="inLanguage">en</fn:string>
+            <fn:string key="encodingFormat">html</fn:string>
+            <fn:string key="license">http://creativecommons.org/publicdomain/zero/1.0</fn:string>
+        </fn:map>
+    </xsl:variable>
     <!-- key -->
     <xsl:key name="datacite" match="collection/resource" use="title"/>
 
@@ -37,6 +61,7 @@
                         rel="stylesheet" type="text/css"/>
                     <link rel="icon" type="image/png"
                         href="https://uwlib-cams.github.io/webviews/images/book.png"/>
+                    <script type="application/ld+json">{xml-to-json($schema)}</script>
                 </head>
                 <body>
                     <h1 id="top">University of Washington Libraries Semantic Web Data</h1>


### PR DESCRIPTION
Update temp_index.xsl to output HTML with basic schema.org markup typing the resource as a schema:DataCatalog, providing creator and publisher, etc. Besides changes to temp_index.xsl, changes to:

- index.html (new index page, with markup)
- temp_index_categories.xml (fixes required to match on resource titles in DataCite metadata

I'll go ahead and merge, as @cspayne has reviewed this. But if further changes to schema markup are desired following review by @gerontakos , these can be made easily in temp_index.xsl.